### PR TITLE
fix register duplicate project path c:\... and C:\... on Windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export async function findProjectRootDirectory(
     }
   }
   if (dirCandidate.length) {
-    return dirCandidate
+    return dirCandidate.replace(/^c:\\/, 'C:\\')
   }
   return
 }


### PR DESCRIPTION
Now, depending on how the directory is opened, the project is registered as follows, and when `CocList project` is executed,`c:\ repos\coc-project` and `~\repos\coc-project` are duplicated. Is displayed.
```sh
$ pwd
~/repos/coc-project
$ nvim
-> register C:\repos\coc-project
$ nvim src/index.ts 
-> register c:\repos\coc-project
```

Therefore, c: \ is replaced with C: \ when searching for the project root.
I am not familiar with coc extension, so it may not be a good way to fix it, but please check it. 

Environment: 
I use Windows 10 and Nyagos as shell.